### PR TITLE
Internal message sending system should use timestamp and username

### DIFF
--- a/app/code/authentication/index.js
+++ b/app/code/authentication/index.js
@@ -11,8 +11,12 @@ class Authentication extends require('../component/index.js') {
     const Schema = app.component('./database/index.js').mongoose().Schema;
     const UserDetail = new Schema({
       username: String,
-      password: String
+      password: String,
+    }, {
+      // This will add createdAt and updatedAt fields.
+      timestamps: true
     });
+
     UserDetail.plugin(this.passportLocalMongoose());
     this.myUserDetails = app.c('database').mongoose().model('userInfo', UserDetail, 'userInfo');
 

--- a/app/code/chat/index.js
+++ b/app/code/chat/index.js
@@ -12,10 +12,17 @@ class Chat extends require('../component/index.js') {
   async init(app)  {
     super.init(app);
 
-    this.myMessage = app.component('./database/index.js').mongoose().model('Message', {
+    const Schema = app.component('./database/index.js').mongoose().Schema;
+    const Message = new Schema({
       name : String,
-      message : String,
+      message : String
+    },
+    {
+      // This will add createdAt and updatedAt fields.
+      timestamps: true
     });
+
+    this.myMessage = app.component('./database/index.js').mongoose().model('Message', Message);
 
     return this;
   }

--- a/app/views/chat.ejs
+++ b/app/views/chat.ejs
@@ -12,8 +12,6 @@
           Welcome <%=name%>. User(s) currently online: <span id="numusers">...</span>
         </div>
         <br>
-        <input id = "name" class="form-control" placeholder="Name">
-        <br>
         <textarea id = "message" class="form-control" placeholder="Your Message Here">
 </textarea>
         <br>
@@ -32,8 +30,9 @@
     <script>
       $(() => {
       $("#send").click(()=>{
+        const messagesender = "<%=name%>";
          sendMessage({
-            name: $("#name").val(),
+            name: messagesender,
             message:$("#message").val()});
           })
         getMessages()

--- a/tests/browser-tests/testSmoke.js
+++ b/tests/browser-tests/testSmoke.js
@@ -45,3 +45,61 @@ it('It should be possible to log in and see the app', async function() {
   }
   await browser.close();
 });
+
+
+it('Confirm that username of a message sender is same as the logged in user.', async function() {
+  this.timeout(25000);
+  const puppeteer = require('puppeteer');
+  const browser = await puppeteer.launch({
+     headless: true,
+     args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
+  var result = false;
+  try {
+    const randomMessage = 'A random number is ' + String(Math.random());
+    const randomMessage2 = 'A random number is ' + String(Math.random());
+
+    console.log('Testing ' + __filename);
+    const page = await browser.newPage();
+    console.log('set viewport');
+    await page.setViewport({ width: 1280, height: 800 });
+    console.log('go to the home page');
+    await page.goto('http://node:8080');
+
+    await page.type('[name=username]', 'admin');
+    await page.type('[name=password]', process.env.ADMIN_PASSWORD);
+    await page.keyboard.press('Enter');
+    await page.waitForSelector('#messages');
+
+    const page2 = await browser.newPage();
+    await page2.goto('http://node:8080');
+    // first message.
+    await testBase.assertInSourceCode(page, 'Send Message', 'home');
+    await page.type('#message', randomMessage);
+    await page.click('#send');
+
+    // second message.
+    await testBase.assertInSourceCode(page, 'Send Message', 'home');
+    await page.type('#message', randomMessage2);
+    await page.click('#send');
+
+    // Get all <h4> elements within #messages
+    const h4Texts = await page.$$eval('#messages .message-single h4', elements =>
+      elements.map(el => el.innerText)
+    );
+
+    // Assert that all <h4> elements contain 'admin'
+    h4Texts.forEach(text => {
+      expect(text).to.equal('admin');
+    });
+
+    console.log('All messages have "admin" as the sender.');
+
+    await testBase.screenshot(page, 'home', await page.content());
+
+  }
+  catch (error) {
+    await testBase.showError(error, browser);
+  }
+  await browser.close();
+});


### PR DESCRIPTION
I have added 

`
 {
      // This will add createdAt and updatedAt fields.
      timestamps: true
     }
`

code to userInfo and messages schema. this will create createdAt and updatedAt properties in userinfo and messages collections. createdAt and updatedAt values taken care by mongoose itself.



I have removed username  input textbox, instead I am passing "name" to sendmessage in javascript of app/views/chat.ejs file.  

