### PR TITLE
Chat bot and welcome page should show merged account, not logged-in account #75

### DIFF
--- a/app/code/accountFramework/index.js
+++ b/app/code/accountFramework/index.js
@@ -237,6 +237,7 @@ class AccountFramework extends require('../component/index.js') {
 
   async run(app) {
     const that = this;
+    // /get-username/<userid> path gets the user details from account framework.
     app.c('express').addRoute('userDetails', 'get', '/get-username', async (req, res) => {
       const userdetails = await that.getAccounts(req.query.userid);
       if (userdetails) {

--- a/app/code/accountFramework/index.js
+++ b/app/code/accountFramework/index.js
@@ -235,6 +235,19 @@ class AccountFramework extends require('../component/index.js') {
     }
   }
 
+  async run(app) {
+    const that = this;
+    app.c('express').addRoute('userDetails', 'get', '/get-username', async (req, res) => {
+      const userdetails = await that.getAccounts(req.query.userid);
+      if (userdetails) {
+        res.header('Content-Type', 'application/json');
+        res.send(JSON.stringify(userdetails['0']));
+      }
+    });
+
+    return this;
+  }
+
 }
 
 module.exports = new AccountFramework();

--- a/app/code/authentication/index.js
+++ b/app/code/authentication/index.js
@@ -288,6 +288,10 @@ class Authentication extends require('../component/index.js') {
     return (await this.userDetails().find({_id: ObjectId(id)})).length;
   }
 
+  async getUserInfoById(id) {
+    return await this.userDetails().find(id);
+  }
+
   async user(name) {
     if (await this.userExists(name)) {
       return (await this.userDetails().find({username: name}))[0];

--- a/app/code/authentication/index.js
+++ b/app/code/authentication/index.js
@@ -289,7 +289,7 @@ class Authentication extends require('../component/index.js') {
   }
 
   async getUserInfoById(id) {
-    return await this.userDetails().find(id);
+    return await this.userDetails().findById(id);
   }
 
   async user(name) {
@@ -309,6 +309,21 @@ class Authentication extends require('../component/index.js') {
       throw Error('User does not exist');
     }
   }
+
+  async run(app) {
+    const that = this;
+    // /get-username/<userid> path gets the user details from account framework.
+    app.c('express').addRoute('userInfo', 'get', '/get-userInfo-username', async (req, res) => {
+      const userdetails = await that.getUserInfoById(req.query.userid);
+      if (userdetails) {
+        res.header('Content-Type', 'application/json');
+        res.send(JSON.stringify(userdetails));
+      }
+    });
+
+    return this;
+  }
+
 }
 
 module.exports = new Authentication();

--- a/app/code/chat/index.js
+++ b/app/code/chat/index.js
@@ -14,7 +14,8 @@ class Chat extends require('../component/index.js') {
 
     const Schema = app.component('./database/index.js').mongoose().Schema;
     const Message = new Schema({
-      name : String,
+      // Reference to the User model
+      name: { type: Schema.Types.ObjectId, ref: 'userInfo' },
       message : String
     },
     {

--- a/app/code/chat/index.js
+++ b/app/code/chat/index.js
@@ -14,8 +14,10 @@ class Chat extends require('../component/index.js') {
 
     const Schema = app.component('./database/index.js').mongoose().Schema;
     const Message = new Schema({
+      // name of a messege sender.
+      name: String,
       // Reference to the User model
-      name: { type: Schema.Types.ObjectId, ref: 'userInfo' },
+      accountFrameworkname: { type: Schema.Types.ObjectId, ref: 'userInfo' },
       message : String
     },
     {

--- a/app/code/chat/plugins/dashboardApi/all.js
+++ b/app/code/chat/plugins/dashboardApi/all.js
@@ -3,7 +3,7 @@
  */
 class PluginChatDashboardApiAll {
   invoke(app, callback) {
-    app.c('chat').message().find({})
+    app.c('chat').message().find({}).populate('name')
       .then((messages) => {
         callback([
           new (app.class('dashboardApi/dashboardSingleNumber'))('Chat messages', messages.length),

--- a/app/code/chatApi/index.js
+++ b/app/code/chatApi/index.js
@@ -18,12 +18,15 @@ class ChatApi extends require('../component/index.js') {
     const path = '/messages';
 
     app.c('express').addRoute('chatApi', 'post', path, (req, res) => {
+      if (req.user) {
+        req.body.name = req.user._id;
+      }
       app.c('chat').addMessage(req.body);
       res.sendStatus(200);
     });
 
     app.c('express').addRoute('chatApi', 'get', path, (req, res) => {
-      app.c('chat').message().find({})
+      app.c('chat').message().find({}).populate('name')
         .then((messages) => {
           res.send(messages);
         });

--- a/app/code/chatApi/index.js
+++ b/app/code/chatApi/index.js
@@ -18,6 +18,8 @@ class ChatApi extends require('../component/index.js') {
     const path = '/messages';
 
     app.c('express').addRoute('chatApi', 'post', path, (req, res) => {
+      // update messge sender name with user id so that it will help us in fetching
+      // username from account framework.
       if (req.user) {
         req.body.name = req.user._id;
       }

--- a/app/code/chatApi/index.js
+++ b/app/code/chatApi/index.js
@@ -17,10 +17,15 @@ class ChatApi extends require('../component/index.js') {
 
     const path = '/messages';
 
-    app.c('express').addRoute('chatApi', 'post', path, (req, res) => {
+    app.c('express').addRoute('chatApi', 'post', path, async (req, res) => {
       // update messge sender name with user id so that it will help us in fetching
       // username from account framework.
       if (req.user) {
+        const userdetails = await app.c('accountFramework').getAccounts(req.user._id);
+        if (userdetails) {
+          req.body.accountFrameworkname = userdetails['0']._id;
+        }
+
         req.body.name = req.user._id;
       }
       app.c('chat').addMessage(req.body);
@@ -28,7 +33,7 @@ class ChatApi extends require('../component/index.js') {
     });
 
     app.c('express').addRoute('chatApi', 'get', path, (req, res) => {
-      app.c('chat').message().find({}).populate('name')
+      app.c('chat').message().find({}).populate('accountFrameworkname')
         .then((messages) => {
           res.send(messages);
         });

--- a/app/code/chatWeb/index.js
+++ b/app/code/chatWeb/index.js
@@ -15,9 +15,14 @@ class ChatWeb extends require('../component/index.js') {
     const path = app.config().modules['./chatWeb/index.js'].path;
     const io = app.c('socket').socketIoHttp();
 
-    app.c('express').addRoute('chat', 'get', path, (req, res) => {
+    app.c('express').addRoute('chat', 'get', path, async (req, res) => {
+      const users = await app.c('accountFramework').getAccounts(req.user._id);
+      let name = req.user.username;
+      if (users) {
+        name = users['0'].username;
+      }
       res.render('chat', {
-        name: req.user.username,
+        name: name
       });
     });
 

--- a/app/code/chatWeb/index.js
+++ b/app/code/chatWeb/index.js
@@ -16,6 +16,7 @@ class ChatWeb extends require('../component/index.js') {
     const io = app.c('socket').socketIoHttp();
 
     app.c('express').addRoute('chat', 'get', path, async (req, res) => {
+      // show name from merged account username in Send message page.
       const users = await app.c('accountFramework').getAccounts(req.user._id);
       let name = req.user.username;
       if (users) {

--- a/app/config/versioned.yml
+++ b/app/config/versioned.yml
@@ -10,6 +10,8 @@ modules:
         verb: post
       - route: CrashTest
         verb: get
+      - route: userDetails
+        verb: get
     authenticatedJson:
       - route: tokenRequest
         verb: get

--- a/app/config/versioned.yml
+++ b/app/config/versioned.yml
@@ -12,6 +12,8 @@ modules:
         verb: get
       - route: userDetails
         verb: get
+      - route: userInfo
+        verb: get
     authenticatedJson:
       - route: tokenRequest
         verb: get

--- a/app/private/private.html
+++ b/app/private/private.html
@@ -51,13 +51,22 @@
 
       function formatMessage(message) {
         let ret = '<div class="message-single">';
-        ret += '<h4>' + htmlEncode(message.name) + '</h4>';
+        ret += '<h4>' + htmlEncode(message.name.username ? message.name.username : message.name) + '</h4>';
         ret += '<p>' + htmlEncode(message.message) +'</p>';
         return ret + '</div>';
       }
 
       function addMessages(message) {
         $("#messages").append(formatMessage(message));
+      }
+
+      function addMessagesAfterFetchingUsername(message){
+        $.get('/get-username?userid=' + message.name, (data) => {
+          if (data.username) {
+            message.name = data.username;
+          }
+          $("#messages").append(formatMessage(message));
+        })
       }
 
       function getMessages(){
@@ -75,7 +84,8 @@
       function updateNumUsers(users) {
         $("#numusers").html(users);
       }
-      socket.on('message', addMessages);
+
+      socket.on('message', addMessagesAfterFetchingUsername);
       socket.on('updateNumUsers', updateNumUsers);
     </script>
   </body>

--- a/app/views/chat.ejs
+++ b/app/views/chat.ejs
@@ -50,13 +50,22 @@
 
       function formatMessage(message) {
         let ret = '<div class="message-single">';
-        ret += '<h4>' + htmlEncode(message.name) + '</h4>';
+        ret += '<h4>' + htmlEncode(message.name.username ? message.name.username : message.name) + '</h4>';
         ret += '<p>' + htmlEncode(message.message) +'</p>';
         return ret + '</div>';
       }
 
       function addMessages(message) {
         $("#messages").append(formatMessage(message));
+      }
+
+      function addMessagesAfterFetchingUsername(message){
+        $.get('/get-username?userid=' + message.name, (data) => {
+          if (data.username) {
+            message.name = data.username;
+          }
+          $("#messages").append(formatMessage(message));
+        })
       }
 
       function getMessages(){
@@ -74,7 +83,7 @@
       function updateNumUsers(users) {
         $("#numusers").html(users);
       }
-      socket.on('message', addMessages);
+      socket.on('message', addMessagesAfterFetchingUsername);
       socket.on('updateNumUsers', updateNumUsers);
     </script>
   </body>

--- a/app/views/chat.ejs
+++ b/app/views/chat.ejs
@@ -59,6 +59,11 @@
         $("#messages").append(formatMessage(message));
       }
 
+      // when user clicks on send message without refreshing page we are appending
+      // message to message history. socket on receiving message,
+      // calls addMessagesAfterFetchingUsername method.
+      // addMessagesAfterFetchingUsername fetches username from
+      // message object name (which is a currently logged in user id)
       function addMessagesAfterFetchingUsername(message){
         $.get('/get-username?userid=' + message.name, (data) => {
           if (data.username) {
@@ -83,6 +88,8 @@
       function updateNumUsers(users) {
         $("#numusers").html(users);
       }
+
+
       socket.on('message', addMessagesAfterFetchingUsername);
       socket.on('updateNumUsers', updateNumUsers);
     </script>

--- a/app/views/chat.ejs
+++ b/app/views/chat.ejs
@@ -49,8 +49,11 @@
       }
 
       function formatMessage(message) {
+        const result = (typeof message.accountFrameworkname === 'object' && message.accountFrameworkname !== null)
+          ? message.accountFrameworkname.username
+          : message.name;
         let ret = '<div class="message-single">';
-        ret += '<h4>' + htmlEncode(message.name.username ? message.name.username : message.name) + '</h4>';
+        ret += '<h4>' + htmlEncode(result) + '</h4>';
         ret += '<p>' + htmlEncode(message.message) +'</p>';
         return ret + '</div>';
       }
@@ -62,10 +65,10 @@
       // when user clicks on send message without refreshing page we are appending
       // message to message history. socket on receiving message,
       // calls addMessagesAfterFetchingUsername method.
-      // addMessagesAfterFetchingUsername fetches username from
-      // message object name (which is a currently logged in user id)
+      // addMessagesAfterFetchingUsername fetches username from user id of a
+      // accountFramework merged user id.
       function addMessagesAfterFetchingUsername(message){
-        $.get('/get-username?userid=' + message.name, (data) => {
+        $.get('/get-userinfo-username?userid=' + message.accountFrameworkname, (data) => {
           if (data.username) {
             message.name = data.username;
           }
@@ -91,6 +94,7 @@
 
 
       socket.on('message', addMessagesAfterFetchingUsername);
+      // socket.on('message', addMessages);
       socket.on('updateNumUsers', updateNumUsers);
     </script>
   </body>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,4 @@
 ---
-version: '2'
-
 services:
   mail:
     # Dummy email client for development, see ./README.md.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '2'
-
 services:
   node:
     build: .


### PR DESCRIPTION
You can test this by clone [chatbot-merged-account](https://github.com/dcycle/starterkit-node/tree/chatbot-merged-account) branch 




```
./scripts/destroy.sh
./scripts/deploy.sh
./scripts/reset-password.sh a
./scripts/reset-password.sh b

```


Now there will be three accounts. You can see this by doing:

```
> ./scripts/mongo-cli.sh

> use login
> db.userInfo.find().pretty();

```
You will see somethng like this:

```
{
  "_id" : ObjectId("67ae71c52c3c4b5f776e719e"),
  "username" : "admin",
  "salt" : "facd528400231f5cfe80d3b0cdfef3b7775bd94f59c90ef45d764ac2acfcd2d5",
  "hash" : "...",
  "createdAt" : ISODate("2025-02-13T22:27:17.985Z"),
  "updatedAt" : ISODate("2025-02-13T22:27:17.985Z"),
  "__v" : 0
}
{
  "_id" : ObjectId("67ae71c69c12a39a80bb9021"),
  "username" : "a",
  "salt" : "59f0b02ff49d0be59c431e4ddacb59835dcdbfd78153500215dccb36c34613f1",
  "hash" : "...",
  "createdAt" : ISODate("2025-02-13T22:27:18.618Z"),
  "updatedAt" : ISODate("2025-02-13T22:27:18.618Z"),
  "__v" : 0
}
{
  "_id" : ObjectId("67ae71c7215c14bdbf49b24b"),
  "username" : "b",
  "salt" : "3969515ef2afb9b89e25438c449ab3a80675dd74c23db8d27f0120ce9cc619fa",
  "hash" : "...",
  "createdAt" : ISODate("2025-02-13T22:27:19.232Z"),
  "updatedAt" : ISODate("2025-02-13T22:27:19.232Z"),
  "__v" : 0
}

````
So, in this example:

user admin has id 67ae71c52c3c4b5f776e719e
user a has id 67ae71c69c12a39a80bb9021
user b has id 67ae71c7215c14bdbf49b24b

Now in two separate browsers, you can log in as a and b.

As user a, type in the chat: hello I am a.
As user b, type in the chat: hello I am b.

On both accounts you will see:

a
hello I am a

b
hello I am b

In the database, you will see this:

```
> ./scripts/mongo-cli.sh


> use login;
> db.messages.find().pretty();

```
You will see something like this: message sender name is replaced with user id.

```
{
  "_id" : ObjectId("67ae72c3eb3f187a1ef275ce"),
  "name" : "67ae71c69c12a39a80bb9021",
  "message" : "hello I am a\n",
  "createdAt" : ISODate("2025-02-13T22:31:31.115Z"),
  "updatedAt" : ISODate("2025-02-13T22:31:31.115Z"),
  "__v" : 0
}
{
  "_id" : ObjectId("67ae72c8eb3f187a1ef275d3"),
  "name" : "67ae71c7215c14bdbf49b24b",
  "message" : "hello I am b",
  "createdAt" : ISODate("2025-02-13T22:31:36.677Z"),
  "updatedAt" : ISODate("2025-02-13T22:31:36.677Z"),
  "__v" : 0
}
```

But in the user interface, we will see the user names, like this:

a
hello I am a

b
hello I am b


2. 

access node cli ./scripts/node-cli.sh and merge a and b account.

```
> await app.c('accountFramework').merge('67ae71c69c12a39a80bb9021', '67ae71c7215c14bdbf49b24b');
```
Now accounts a and b are merged, as you can see at:

```
await app.c('accountFramework').getAccounts('67ae71c69c12a39a80bb9021');
[
  {
    _id: new ObjectId('67ae71c69c12a39a80bb9021'),
    username: 'a',
    createdAt: 2025-02-13T22:27:18.618Z,
    updatedAt: 2025-02-13T22:30:32.585Z,
    __v: 0
  },
  {
    _id: new ObjectId('67ae71c7215c14bdbf49b24b'),
    username: 'b',
    createdAt: 2025-02-13T22:27:19.232Z,
    updatedAt: 2025-02-13T22:31:11.742Z,
    __v: 0
  }
]
```

Because a is the first in the list, then the new merged account be known as "a".

Therefore, when you log in either as "a" or "b", you will now see the following chat:

a
hello I am a

a
hello I am b


3. 
Under "Send Message", when you log in with either a or b, now that a and b are merged, instead of seeing:

Welcome b

you should see

Welcome a

